### PR TITLE
Remove unsupported configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This [cloud controller manager](https://kubernetes.io/docs/concepts/architecture
 
 - **Instances Controller**: Manages node lifecycle and updates node metadata with cloud-specific information
 - **Zones Controller**: Provides availability zone information for nodes
-- **Routes Controller**: Manages pod network routes using BinaryLane VPC Route Entries
 
 
 The cloud controller manager automatically applies the following labels to nodes:
@@ -41,7 +40,7 @@ kubectl create secret generic binarylane-api-token \
 # Install the chart from GitHub Container Registry
 helm install binarylane-ccm \
   oci://ghcr.io/oscarhermoso/charts/binarylane-cloud-controller-manager \
-  --version 0.1.2 \
+  --version 0.2.2 \
   --namespace kube-system \
   --set cloudControllerManager.secret.name="binarylane-api-token"
 ```
@@ -74,7 +73,7 @@ kubectl apply -f https://raw.githubusercontent.com/oscarhermoso/binarylane-cloud
 
 ### Environment Variables
 
-- `BINARYLANE_ACCESS_TOKEN` (required): Your BinaryLane API token
+- `BINARYLANE_API_TOKEN` (required): Your BinaryLane API token
 
 ## Contributing
 

--- a/charts/binarylane-cloud-controller-manager/README.md
+++ b/charts/binarylane-cloud-controller-manager/README.md
@@ -18,7 +18,6 @@ The following table lists the configurable parameters of the chart and their def
 | `image.tag`                          | Image tag                           | Chart appVersion                                           |
 | `cloudControllerManager.secret.name` | Name of secret containing API token | `""`                                                       |
 | `cloudControllerManager.secret.key`  | Key in secret for API token         | `api-token`                                                |
-| `cloudControllerManager.apiUrl`      | BinaryLane API URL                  | `https://api.binarylane.com.au`                            |
 | `serviceAccount.create`              | Create service account              | `true`                                                     |
 | `serviceAccount.name`                | Service account name                | Generated from template                                    |
 | `resources.limits.cpu`               | CPU limit                           | `200m`                                                     |
@@ -51,7 +50,6 @@ cloudControllerManager:
 cloudControllerManager:
   secret:
     name: "binarylane-api-token"
-  apiUrl: "https://api.binarylane.com.au"
 
 replicaCount: 2
 
@@ -64,8 +62,8 @@ resources:
     memory: 128Mi
 
 extraArgs:
-  - "--cluster-cidr=10.244.0.0/16"
-  - "--configure-cloud-routes=false"
+  - "--kube-api-qps=50"
+  - "--kube-api-burst=100"
 
 extraEnv:
   - name: HTTP_PROXY
@@ -82,31 +80,6 @@ tolerations:
     operator: Equal
     value: "true"
     effect: NoSchedule
-```
-
-### Using with Custom Node Labels
-
-```yaml
-# values-custom-nodes.yaml
-cloudControllerManager:
-  apiToken: "your-api-token-here"
-
-nodeSelector:
-  node-role.kubernetes.io/control-plane: ""
-  custom-label: "ccm"
-
-affinity:
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - binarylane-cloud-controller-manager
-          topologyKey: kubernetes.io/hostname
 ```
 
 ## Upgrading

--- a/charts/binarylane-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/binarylane-cloud-controller-manager/templates/deployment.yaml
@@ -46,22 +46,16 @@ spec:
             - --cloud-provider=binarylane
             - --leader-elect=true
             - --use-service-account-credentials=true
-            - --allocate-node-cidrs=true
-            - --configure-cloud-routes=false
             - --v={{ .Values.verbosity }}
             {{- range .Values.extraArgs }}
             - {{ . }}
             {{- end }}
           env:
-            - name: BINARYLANE_ACCESS_TOKEN
+            - name: BINARYLANE_API_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ required "cloudControllerManager.secret.name is required" .Values.cloudControllerManager.secret.name }}
                   key: {{ .Values.cloudControllerManager.secret.key }}
-            {{- if .Values.cloudControllerManager.apiUrl }}
-            - name: BINARYLANE_API_URL
-              value: {{ .Values.cloudControllerManager.apiUrl | quote }}
-            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/binarylane-cloud-controller-manager/tests/deployment_test.yaml
+++ b/charts/binarylane-cloud-controller-manager/tests/deployment_test.yaml
@@ -4,10 +4,11 @@ templates:
   - serviceaccount.yaml
   - secret.yaml
   - rbac.yaml
+  - test-secret.yaml
 tests:
   - it: should create a deployment with correct replicas
     set:
-      cloudControllerManager.apiToken: 'test-token'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
     asserts:
       - isKind:
           of: Deployment
@@ -17,7 +18,7 @@ tests:
 
   - it: should use correct image
     set:
-      cloudControllerManager.apiToken: 'test-token'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
       image.repository: 'custom-repo'
       image.tag: 'v1.0.0'
     asserts:
@@ -25,39 +26,23 @@ tests:
           path: spec.template.spec.containers[0].image
           value: 'custom-repo:v1.0.0'
 
-  - it: should create secret when not using existing secret
-    template: secret.yaml
+  - it: should reference token secret via env var
     set:
-      cloudControllerManager.apiToken: 'test-token'
-    asserts:
-      - isKind:
-          of: Secret
-      - equal:
-          path: stringData.api-token
-          value: 'test-token'
-
-  - it: should not create secret when using existing secret
-    template: secret.yaml
-    set:
-      cloudControllerManager.existingSecret: 'my-secret'
-    asserts:
-      - hasDocuments:
-          count: 0
-
-  - it: should have correct environment variables
-    set:
-      cloudControllerManager.apiToken: 'test-token'
-      cloudControllerManager.apiUrl: 'https://api.test.com'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
+      cloudControllerManager.secret.key: 'api-token'
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: BINARYLANE_API_URL
-            value: 'https://api.test.com'
+            name: BINARYLANE_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: binarylane-api-token
+                key: api-token
 
   - it: should use correct service account
     set:
-      cloudControllerManager.apiToken: 'test-token'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
       serviceAccount.name: 'custom-sa'
     asserts:
       - equal:
@@ -66,7 +51,7 @@ tests:
 
   - it: should apply tolerations
     set:
-      cloudControllerManager.apiToken: 'test-token'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
     asserts:
       - contains:
           path: spec.template.spec.tolerations
@@ -77,7 +62,7 @@ tests:
 
   - it: should apply node selector
     set:
-      cloudControllerManager.apiToken: 'test-token'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
     asserts:
       - equal:
           path: spec.template.spec.nodeSelector
@@ -86,7 +71,7 @@ tests:
 
   - it: should use host network
     set:
-      cloudControllerManager.apiToken: 'test-token'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
     asserts:
       - equal:
           path: spec.template.spec.hostNetwork
@@ -94,7 +79,7 @@ tests:
 
   - it: should have security context
     set:
-      cloudControllerManager.apiToken: 'test-token'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
     asserts:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
@@ -106,7 +91,7 @@ tests:
   - it: should create RBAC resources
     template: rbac.yaml
     set:
-      cloudControllerManager.apiToken: 'test-token'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
     asserts:
       - hasDocuments:
           count: 2
@@ -119,21 +104,34 @@ tests:
 
   - it: should apply extra args
     set:
-      cloudControllerManager.apiToken: 'test-token'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
       extraArgs:
-        - '--configure-cloud-routes=true'
-        - '--cluster-cidr=10.244.0.0/16'
+        - '--kube-api-qps=50'
+        - '--kube-api-burst=100'
     asserts:
       - contains:
           path: spec.template.spec.containers[0].command
-          content: '--configure-cloud-routes=true'
+          content: '--kube-api-qps=50'
       - contains:
           path: spec.template.spec.containers[0].command
-          content: '--cluster-cidr=10.244.0.0/16'
+          content: '--kube-api-burst=100'
+
+  - it: should create test secret when enabled
+    template: test-secret.yaml
+    set:
+      createTestSecret: true
+      cloudControllerManager.secret.name: 'binarylane-api-token'
+      cloudControllerManager.secret.key: 'api-token'
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.api-token
+          value: 'test-token-for-ci'
 
   - it: should set resource limits
     set:
-      cloudControllerManager.apiToken: 'test-token'
+      cloudControllerManager.secret.name: 'binarylane-api-token'
       resources:
         limits:
           cpu: '500m'

--- a/charts/binarylane-cloud-controller-manager/values-example.yaml
+++ b/charts/binarylane-cloud-controller-manager/values-example.yaml
@@ -19,9 +19,6 @@ cloudControllerManager:
     name: 'binarylane-api-token'
     key: 'api-token'
 
-  # BinaryLane API URL (use default unless testing)
-  apiUrl: 'https://api.binarylane.com.au'
-
 # Service account configuration
 serviceAccount:
   create: true
@@ -97,27 +94,13 @@ hostNetwork: true
 verbosity: 2
 
 # Additional command-line arguments
-extraArgs:
-  []
-  # - --cluster-cidr=10.244.0.0/16
-  # - --configure-cloud-routes=false
+extraArgs: []
 
 # Additional environment variables
-extraEnv:
-  []
-  # - name: HTTP_PROXY
-  #   value: "http://proxy.example.com:8080"
+extraEnv: []
 
 # Additional volumes
-extraVolumes:
-  []
-  # - name: ca-certs
-  #   hostPath:
-  #     path: /etc/ssl/certs
+extraVolumes: []
 
 # Additional volume mounts
-extraVolumeMounts:
-  []
-  # - name: ca-certs
-  #   mountPath: /etc/ssl/certs
-  #   readOnly: true
+extraVolumeMounts: []

--- a/charts/binarylane-cloud-controller-manager/values.yaml
+++ b/charts/binarylane-cloud-controller-manager/values.yaml
@@ -23,8 +23,6 @@ cloudControllerManager:
   secret:
     name: ''
     key: 'api-token'
-  # BinaryLane API URL
-  apiUrl: 'https://api.binarylane.com.au'
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -116,26 +114,13 @@ service:
 verbosity: 2
 
 # Extra arguments to pass to the cloud controller manager
-extraArgs:
-  []
-  # - --configure-cloud-routes=false
+extraArgs: []
 
 # Extra environment variables
-extraEnv:
-  []
-  # - name: HTTP_PROXY
-  #   value: "http://proxy.example.com:8080"
+extraEnv: []
 
 # Extra volumes
-extraVolumes:
-  []
-  # - name: ca-certs
-  #   hostPath:
-  #     path: /etc/ssl/certs
+extraVolumes: []
 
 # Extra volume mounts
-extraVolumeMounts:
-  []
-  # - name: ca-certs
-  #   mountPath: /etc/ssl/certs
-  #   readOnly: true
+extraVolumeMounts: []

--- a/cmd/binarylane-cloud-controller-manager/main.go
+++ b/cmd/binarylane-cloud-controller-manager/main.go
@@ -1,20 +1,21 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/oscarhermoso/binarylane-cloud-controller-manager/internal/cloud"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider/app"
 	"k8s.io/cloud-provider/app/config"
+	"k8s.io/cloud-provider/names"
 	"k8s.io/cloud-provider/options"
+	"k8s.io/component-base/cli"
 	cliflag "k8s.io/component-base/cli/flag"
-	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
 	_ "k8s.io/component-base/metrics/prometheus/version"
 	"k8s.io/klog/v2"
+
+	_ "github.com/oscarhermoso/binarylane-cloud-controller-manager/internal/cloud"
 )
 
 func main() {
@@ -24,44 +25,43 @@ func main() {
 	}
 
 	controllerInitializers := app.DefaultInitFuncConstructors
+	controllerAliases := names.CCMControllerAliases()
 	fss := cliflag.NamedFlagSets{}
-	featureGates := make(map[string]string)
 
 	command := app.NewCloudControllerManagerCommand(
 		opts,
 		cloudInitializer,
 		controllerInitializers,
-		featureGates,
+		controllerAliases,
 		fss,
 		wait.NeverStop,
 	)
+	command.Use = "binarylane-cloud-controller-manager"
 
-	logs.InitLogs()
-	defer logs.FlushLogs()
-
-	if err := command.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
+	code := cli.Run(command)
+	os.Exit(code)
 }
 
 func cloudInitializer(config *config.CompletedConfig) cloudprovider.Interface {
 	cloudConfig := config.ComponentConfig.KubeCloudShared.CloudProvider
-
-	token := os.Getenv("BINARYLANE_ACCESS_TOKEN")
-	if token == "" {
-		klog.Fatalf("BINARYLANE_ACCESS_TOKEN environment variable is required")
-	}
-
-	cloudProvider, err := cloud.NewCloud(token, config.ComponentConfig.KubeCloudShared.ClusterCIDR)
+	cloud, err := cloudprovider.InitCloudProvider(cloudConfig.Name, cloudConfig.CloudConfigFile)
 	if err != nil {
-		klog.Fatalf("failed to initialize BinaryLane cloud provider: %v", err)
+		klog.Fatalf("Cloud provider could not be initialized: %v", err)
+	}
+	if cloud == nil {
+		klog.Fatalf("Cloud provider is nil")
 	}
 
-	cloudProvider.Initialize(config.ClientBuilder, wait.NeverStop)
+	// TODO: Uncomment after cluster IDs are implemented
+	// if !cloud.HasClusterID() {
+	// 	if config.ComponentConfig.KubeCloudShared.AllowUntaggedCloud {
+	// 		klog.Warning("detected a cluster without a ClusterID.  A ClusterID will be required in the future.  Please tag your cluster to avoid any future issues")
+	// 	} else {
+	// 		klog.Fatalf("no ClusterID found.  A ClusterID is required for the cloud provider to function properly.  This check can be bypassed by setting the allow-untagged-cloud option")
+	// 	}
+	// }
 
-	klog.Infof("BinaryLane cloud controller manager initialized (provider: %s)",
-		cloudConfig.Name)
+	// TODO: There's a lot of potentially valuable configuration in config.ComponentConfig.KubeCloudShared..., consider passing it to the cloud provider here
 
-	return cloudProvider
+	return cloud
 }

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -57,18 +57,14 @@ spec:
             - '/binarylane-cloud-controller-manager'
             - '--cloud-provider=binarylane'
             - '--leader-elect=true'
-            - '--use-service-account-credentials'
-            - '--allocate-node-cidrs=true'
-            - '--cluster-cidr=10.244.0.0/16'
+            - '--use-service-account-credentials=true'
             - '--v=2'
           env:
-            - name: BINARYLANE_ACCESS_TOKEN
+            - name: BINARYLANE_API_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: binarylane-api-token
                   key: api-token
-            - name: BINARYLANE_REGION
-              value: 'per' # Change to your region
           resources:
             requests:
               cpu: 100m

--- a/internal/binarylane/client.go
+++ b/internal/binarylane/client.go
@@ -25,6 +25,7 @@ func NewBinaryLaneClient(token string) (*BinaryLaneClient, error) {
 		WithHTTPClient(httpClient),
 		WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("User-Agent", "binarylane-cloud-controller-manager/v0") // TODO: set version dynamically
 			return nil
 		}),
 	)

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/oscarhermoso/binarylane-cloud-controller-manager/internal/binarylane"
 	cloudprovider "k8s.io/cloud-provider"
@@ -19,7 +20,10 @@ type Cloud struct {
 	cidr   string
 }
 
-func NewCloud(token string, cidr string) (cloudprovider.Interface, error) {
+func newCloud(config io.Reader) (cloudprovider.Interface, error) {
+	// TODO: read config?
+
+	token := os.Getenv("BINARYLANE_API_TOKEN")
 	if token == "" {
 		return nil, fmt.Errorf("BinaryLane API token is required")
 	}
@@ -31,7 +35,6 @@ func NewCloud(token string, cidr string) (cloudprovider.Interface, error) {
 
 	return &Cloud{
 		client: client,
-		cidr:   cidr,
 	}, nil
 }
 
@@ -43,7 +46,7 @@ func (c *Cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 }
 
 func (c *Cloud) Instances() (cloudprovider.Instances, bool) {
-	// Replaced by InstancesV2
+	// Replaced by InstancesV2, does not need to be implemented
 	return nil, false
 }
 
@@ -54,7 +57,7 @@ func (c *Cloud) InstancesV2() (cloudprovider.InstancesV2, bool) {
 }
 
 func (c *Cloud) Zones() (cloudprovider.Zones, bool) {
-	// Replaced by InstancesV2
+	// Replaced by InstancesV2, does not need to be implemented
 	return nil, false
 }
 
@@ -81,7 +84,7 @@ func (c *Cloud) HasClusterID() bool {
 }
 
 func init() {
-	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
-		return nil, fmt.Errorf("use NewCloud function to create BinaryLane cloud provider")
-	})
+	// TODO: register metrics here once implemented
+
+	cloudprovider.RegisterCloudProvider(ProviderName, newCloud)
 }

--- a/internal/cloud/instances.go
+++ b/internal/cloud/instances.go
@@ -61,19 +61,14 @@ func (i *instancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*clo
 		},
 	}
 
-	if server.VpcId != nil {
-		for _, net := range server.Networks.V4 {
-			if net.Type == "private" {
-				addresses = append(addresses, v1.NodeAddress{
-					Type:    v1.NodeInternalIP,
-					Address: net.IpAddress,
-				})
-			}
-		}
-	}
-
 	for _, net := range server.Networks.V4 {
-		if net.Type == "public" {
+		switch net.Type {
+		case "private":
+			addresses = append(addresses, v1.NodeAddress{
+				Type:    v1.NodeInternalIP,
+				Address: net.IpAddress,
+			})
+		case "public":
 			addresses = append(addresses, v1.NodeAddress{
 				Type:    v1.NodeExternalIP,
 				Address: net.IpAddress,


### PR DESCRIPTION
* Removed all references to the `apiUrl`/`BINARYLANE_API_URL` configuration, was unsupported.
* Updated Helm chart - removed unsupported arguments (`--cluster-cidr`, `--configure-cloud-routes`, etc.).
* Updated the BinaryLane API client to include a static `User-Agent` header for easier identification.
